### PR TITLE
Delegating metric data (#6195)

### DIFF
--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -1,0 +1,49 @@
+package io.opentelemetry.sdk.metrics.data;
+
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class DelegatingMetricData implements MetricData {
+
+    private final MetricData delegate;
+
+    protected DelegatingMetricData(MetricData delegate) {
+      this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public Resource getResource() {
+      return delegate.getResource();
+    }
+    @Override
+    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+      return delegate.getInstrumentationScopeInfo();
+    }
+
+    @Override
+    public String getName() {
+      return delegate.getName();
+    }
+
+    @Override
+    public String getDescription() {
+      return delegate.getDescription();
+    }
+
+    @Override
+    public String getUnit() {
+      return delegate.getUnit();
+    }
+
+    @Override
+    public MetricDataType getType() {
+      return delegate.getType();
+    }
+
+    @Override
+    public Data<?> getData() {
+      return delegate.getData();
+    }
+}

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -67,6 +67,26 @@ public abstract class DelegatingMetricData implements MetricData {
   }
 
   @Override
+  public int hashCode() {
+    int result = 1;
+    result *= 1000003;
+    result ^= this.getResource().hashCode();
+    result *= 1000003;
+    result ^= this.getInstrumentationScopeInfo().hashCode();
+    result *= 1000003;
+    result ^= this.getName().hashCode();
+    result *= 1000003;
+    result ^= this.getDescription().hashCode();
+    result *= 1000003;
+    result ^= this.getUnit().hashCode();
+    result *= 1000003;
+    result ^= this.getType().hashCode();
+    result *= 1000003;
+    result ^= this.getData().hashCode();
+    return result;
+  }
+
+  @Override
   public String toString() {
     return "DelegatingMetricData{" +
         "resource=" + getResource() + ", " +

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -1,9 +1,9 @@
 package io.opentelemetry.sdk.metrics.data;
 
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
-
-import static java.util.Objects.requireNonNull;
 
 public abstract class DelegatingMetricData implements MetricData {
 
@@ -17,6 +17,7 @@ public abstract class DelegatingMetricData implements MetricData {
   public Resource getResource() {
     return delegate.getResource();
   }
+
   @Override
   public InstrumentationScopeInfo getInstrumentationScopeInfo() {
     return delegate.getInstrumentationScopeInfo();

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -7,43 +7,75 @@ import static java.util.Objects.requireNonNull;
 
 public abstract class DelegatingMetricData implements MetricData {
 
-    private final MetricData delegate;
+  private final MetricData delegate;
 
-    protected DelegatingMetricData(MetricData delegate) {
-      this.delegate = requireNonNull(delegate, "delegate");
-    }
+  protected DelegatingMetricData(MetricData delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
 
-    @Override
-    public Resource getResource() {
-      return delegate.getResource();
-    }
-    @Override
-    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
-      return delegate.getInstrumentationScopeInfo();
-    }
+  @Override
+  public Resource getResource() {
+    return delegate.getResource();
+  }
+  @Override
+  public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+    return delegate.getInstrumentationScopeInfo();
+  }
 
-    @Override
-    public String getName() {
-      return delegate.getName();
-    }
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
 
-    @Override
-    public String getDescription() {
-      return delegate.getDescription();
-    }
+  @Override
+  public String getDescription() {
+    return delegate.getDescription();
+  }
 
-    @Override
-    public String getUnit() {
-      return delegate.getUnit();
-    }
+  @Override
+  public String getUnit() {
+    return delegate.getUnit();
+  }
 
-    @Override
-    public MetricDataType getType() {
-      return delegate.getType();
-    }
+  @Override
+  public MetricDataType getType() {
+    return delegate.getType();
+  }
 
-    @Override
-    public Data<?> getData() {
-      return delegate.getData();
+  @Override
+  public Data<?> getData() {
+    return delegate.getData();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
     }
+    if (o instanceof DelegatingMetricData) {
+      DelegatingMetricData that = (DelegatingMetricData) o;
+      return this.delegate.equals(that.delegate) &&
+          this.getResource().equals(that.getResource()) &&
+          this.getInstrumentationScopeInfo().equals(that.getInstrumentationScopeInfo()) &&
+          this.getName().equals(that.getName()) &&
+          this.getDescription().equals(that.getDescription()) &&
+          this.getUnit().equals(that.getUnit()) &&
+          this.getType().equals(that.getType()) &&
+          this.getData().equals(that.getData());
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "DelegatingMetricData{" +
+        "resource=" + getResource() + ", " +
+        "instrumentationScopeInfo=" + getInstrumentationScopeInfo() + ", " +
+        "name=" + getName() + ", " +
+        "description=" + getDescription() + ", " +
+        "unit=" + getUnit() + ", " +
+        "type=" + getType() + ", " +
+        "data=" + getData() +
+        "}";
+  }
 }

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricData.java
@@ -1,10 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.opentelemetry.sdk.metrics.data;
 
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.Nullable;
 
+/**
+ * A {@link MetricData} which delegates all methods to another {@link MetricData}. Extend this class to
+ * modify the {@link MetricData} that will be exported.
+ */
 public abstract class DelegatingMetricData implements MetricData {
 
   private final MetricData delegate;
@@ -49,20 +58,19 @@ public abstract class DelegatingMetricData implements MetricData {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == this) {
       return true;
     }
-    if (o instanceof DelegatingMetricData) {
-      DelegatingMetricData that = (DelegatingMetricData) o;
-      return this.delegate.equals(that.delegate) &&
-          this.getResource().equals(that.getResource()) &&
-          this.getInstrumentationScopeInfo().equals(that.getInstrumentationScopeInfo()) &&
-          this.getName().equals(that.getName()) &&
-          this.getDescription().equals(that.getDescription()) &&
-          this.getUnit().equals(that.getUnit()) &&
-          this.getType().equals(that.getType()) &&
-          this.getData().equals(that.getData());
+    if (o instanceof MetricData) {
+      MetricData that = (MetricData) o;
+      return getResource().equals(that.getResource()) &&
+          getInstrumentationScopeInfo().equals(that.getInstrumentationScopeInfo()) &&
+          getName().equals(that.getName()) &&
+          getDescription().equals(that.getDescription()) &&
+          getUnit().equals(that.getUnit()) &&
+          getType().equals(that.getType()) &&
+          getData().equals(that.getData());
     }
     return false;
   }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
@@ -1,22 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.opentelemetry.sdk.metrics.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.metrics.TestMetricData;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 
 class DelegatingMetricDataTest {
+
   private static final class NoOpDelegatingMetricData extends DelegatingMetricData {
-    private String description;
     private NoOpDelegatingMetricData(MetricData delegate) {
       super(delegate);
     }
   }
 
-  private static final class MetricDataWithClientDescription extends DelegatingMetricData {
+  private static final class MetricDataWithCustomDescription extends DelegatingMetricData {
     private final String description;
 
-    private MetricDataWithClientDescription(MetricData delegate) {
+    private MetricDataWithCustomDescription(MetricData delegate) {
       super(delegate);
       this.description = "test";
     }
@@ -26,20 +33,34 @@ class DelegatingMetricDataTest {
       return description;
     }
 
-    private static String parseUserAgent(String userAgent) {
-      if (userAgent.startsWith("Mozilla/")) {
-        return "browser";
-      } else if (userAgent.startsWith("Phone/")) {
-        return "phone";
-      }
-      return "unknown";
-    }
   }
 
+  @Test
+  void delegates() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+
+    assertThat(noOpWrapper)
+        .usingRecursiveComparison(
+            RecursiveComparisonConfiguration.builder().withIgnoredFields("delegate").build())
+        .isEqualTo(metricData);
+  }
+
+  @Test
+  void overrideDelegate() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData withCustomDescription = new MetricDataWithCustomDescription(metricData);
+
+    assertThat(withCustomDescription.getDescription()).isEqualTo("test");
+  }
   @Test
   void equals() {
     MetricData metricData = createBasicMetricBuilder().build();
     MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+    MetricData withCustomDescription = new MetricDataWithCustomDescription(metricData);
+
+    assertThat(noOpWrapper).isEqualTo(metricData);
+    assertThat(metricData).isNotEqualTo(withCustomDescription);
   }
 
   private static TestMetricData.Builder createBasicMetricBuilder() {
@@ -48,7 +69,8 @@ class DelegatingMetricDataTest {
         .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
         .setDescription("")
         .setUnit("1")
-        .setData(null)  // TODO: Need to figure out how to set the Data value
+        .setName("name")
+        .setData(ImmutableSummaryData.empty())
         .setType(MetricDataType.SUMMARY); // Not sure what type should be here
   }
 }

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
@@ -1,0 +1,5 @@
+package io.opentelemetry.sdk.metrics.data;
+
+class DelegatingMetricDataTest {
+
+}

--- a/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
+++ b/sdk/metrics/src/test/java/io/opentelemetry/sdk/metrics/data/DelegatingMetricDataTest.java
@@ -1,5 +1,54 @@
 package io.opentelemetry.sdk.metrics.data;
 
-class DelegatingMetricDataTest {
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.metrics.TestMetricData;
+import org.junit.jupiter.api.Test;
 
+class DelegatingMetricDataTest {
+  private static final class NoOpDelegatingMetricData extends DelegatingMetricData {
+    private String description;
+    private NoOpDelegatingMetricData(MetricData delegate) {
+      super(delegate);
+    }
+  }
+
+  private static final class MetricDataWithClientDescription extends DelegatingMetricData {
+    private final String description;
+
+    private MetricDataWithClientDescription(MetricData delegate) {
+      super(delegate);
+      this.description = "test";
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    private static String parseUserAgent(String userAgent) {
+      if (userAgent.startsWith("Mozilla/")) {
+        return "browser";
+      } else if (userAgent.startsWith("Phone/")) {
+        return "phone";
+      }
+      return "unknown";
+    }
+  }
+
+  @Test
+  void equals() {
+    MetricData metricData = createBasicMetricBuilder().build();
+    MetricData noOpWrapper = new NoOpDelegatingMetricData(metricData);
+  }
+
+  private static TestMetricData.Builder createBasicMetricBuilder() {
+    return TestMetricData.builder()
+        .setResource(Resource.empty())
+        .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
+        .setDescription("")
+        .setUnit("1")
+        .setData(null)  // TODO: Need to figure out how to set the Data value
+        .setType(MetricDataType.SUMMARY); // Not sure what type should be here
+  }
 }

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
@@ -1,0 +1,98 @@
+package io.opentelemetry.sdk.testing.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.Data;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.resources.Resource;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@AutoValue
+public abstract class TestMetricData implements MetricData {
+  public static Builder builder() {
+    //TODO: Need to figure out how to set the Data value
+    return new AutoValue_TestMetricData.Builder()
+        .setResource(Resource.empty())
+        .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
+        .setDescription("")
+        .setUnit("1")
+        .setType(MetricDataType.DOUBLE_GAUGE);
+  }
+
+  /** A builder for {@link TestMetricData}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    abstract TestMetricData autoBuild();
+
+    /**
+     * Builds and returns a new {@link MetricData} instance from the data in {@code this}
+     *
+     * @return a new {@link MetricData} instance
+     */
+    public TestMetricData build() {
+      return autoBuild();
+    }
+
+    /**
+     * Sets the resource of the metric
+     *
+     * @param resource the resource of the metric
+     * @return this
+     */
+    public abstract Builder setResource(Resource resource);
+
+    /**
+     * Sets the name of the metric
+     *
+     * @param name the name of the metric
+     * @return this
+     */
+    public abstract Builder setName(String name);
+
+    /**
+     * Sets the description of the metric
+     *
+     * @param description the description of the metric
+     * @return this
+     */
+    public abstract Builder setDescription(String description);
+
+    /**
+     * Sets the unit of the metric
+     *
+     * @param unit the unit of the metric
+     * @return this
+     */
+    public abstract Builder setUnit(String unit);
+
+    /**
+     * Sets the type of the metric
+     *
+     * @param type the type of the metric
+     * @return this
+     */
+    public abstract Builder setType(MetricDataType type);
+
+    /**
+     * Sets the data of the metric
+     *
+     * @param data the data of the metric
+     * @return this
+     */
+    public abstract Builder setData(Data<?> data);
+
+    /**
+     * Sets the Instrumentation scope of the metric
+     *
+     * @param instrumentationScopeInfo the instrumentation scope of the tracer which created this
+     * metric.
+     * @return this
+     */
+    public abstract Builder setInstrumentationScopeInfo(
+        InstrumentationScopeInfo instrumentationScopeInfo);
+
+  }
+
+}

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.opentelemetry.sdk.testing.metrics;
 
 import com.google.auto.value.AutoValue;
@@ -5,20 +9,25 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.Data;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Immutable representation of all data collected by the {@link io.opentelemetry.sdk.metrics.data.MetricData}
+ * class.
+ */
 @Immutable
 @AutoValue
 public abstract class TestMetricData implements MetricData {
   public static Builder builder() {
-    // TODO: Need to figure out how to set the Data value
     return new AutoValue_TestMetricData.Builder()
         .setResource(Resource.empty())
+        .setName("name")
         .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
         .setDescription("description")
         .setUnit("1")
-        .setData(null)
+        .setData(ImmutableSummaryData.empty())
         .setType(MetricDataType.SUMMARY);
   }
 

--- a/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
+++ b/sdk/testing/src/main/java/io/opentelemetry/sdk/testing/metrics/TestMetricData.java
@@ -12,13 +12,14 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 public abstract class TestMetricData implements MetricData {
   public static Builder builder() {
-    //TODO: Need to figure out how to set the Data value
+    // TODO: Need to figure out how to set the Data value
     return new AutoValue_TestMetricData.Builder()
         .setResource(Resource.empty())
         .setInstrumentationScopeInfo(InstrumentationScopeInfo.empty())
-        .setDescription("")
+        .setDescription("description")
         .setUnit("1")
-        .setType(MetricDataType.DOUBLE_GAUGE);
+        .setData(null)
+        .setType(MetricDataType.SUMMARY);
   }
 
   /** A builder for {@link TestMetricData}. */


### PR DESCRIPTION
- Added DelegatingMetricData, based on what I saw was implemented for DelegatingSpanData
- Added files: DelegatingMetricData, TestMetricData (to allow users to create test data), unit tests where applicable